### PR TITLE
Update the link of readme file to point to github wiki

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
 = Mode d'emploi SCIAM Blog
 :toc:
 
-Consultez le https://gitlab.com/sciam/blog-tech/-/wikis/home[Wiki du blog]
+Consultez le https://github.com/SCIAM-FR/sciam-fr.github.io/wiki[Wiki du blog]


### PR DESCRIPTION
L'objectif de cette demande de tirage de mettre à jours le fichier README pour pointer vers le wiki de GitHub au lieu de celui de GitLab 
