### PR TITLE
Integrate tailwind css generation in jekyll build

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -52,7 +52,6 @@ jobs:
           npm update
           npx tailwindcss -i ./css/styles.css -o ./css/output.css --minify
       - name: Build with Jekyll
-        # Outputs to the './_site' directory by default
         run: 
           bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ group :jekyll_plugins do
   gem 'jekyll-seo-tag'
   gem 'jekyll-toc'
   gem 'kramdown-parser-gfm'
+  gem 'jekyll-postcss-v2'
 end
 
 gem "webrick", "~> 1.8"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,7 +28,6 @@
     rel="stylesheet">
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" rel="stylesheet">
   <link href="https://unpkg.com/swiper/swiper-bundle.min.css" rel="stylesheet"/>
-  <link href="{{ './css/output.css' | relative_url }}" rel="stylesheet">
   <link href="{{ './css/styles.css' | relative_url }}" rel="stylesheet">
 
   {% feed_meta %}

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,6 +1,9 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+---
+---
+
+@import "tailwindcss/base";
+@import "tailwindcss/components";
+@import "tailwindcss/utilities";
 
 @font-face {
   font-family: 'Noyh Geometric' ;

--- a/package.json
+++ b/package.json
@@ -6,10 +6,12 @@
     "cssnano": "^7.0.1",
     "prettier": "^3.2.5",
     "prettier-plugin-tailwindcss": "^0.5.14",
-    "tailwindcss": "^3.4.3"
+    "tailwindcss": "^3.4.3",
+    "postcss": "^8.4.39",
+    "postcss-cli": "^11.0.0"
   },
   "scripts": {
-    "build:css": "npx tailwindcss -i ./css/styles.css -o ./css/output.css --watch"
+    "build:css": "npx tailwindcss -i ./css/styles.css -o _site/css/styles.css --watch"
   },
   "dependencies": {
     "@lottiefiles/dotlottie-web": "^0.23.2",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  plugins: [
+    require('postcss-import'),
+    require('tailwindcss'),
+    require('autoprefixer'),
+    ...(process.env.JEKYLL_ENV == "production"
+        ? [require('cssnano')({ preset: 'default' })]
+        : [])
+  ]
+};

--- a/runServer.bat
+++ b/runServer.bat
@@ -1,2 +1,3 @@
 @echo off
+npm install
 bundle exec jekyll serve -t --draft --watch --livereload

--- a/runServer.sh
+++ b/runServer.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
-bundle exec jekyll serve -i -o
+npm install
+bundle exec jekyll serve -l -o
 


### PR DESCRIPTION
fixes #74
Done by using `jekyll-post-css-v2`gem. Simplification of overall build 