### PR TITLE
fix: pagination setup on author auto pages

### DIFF
--- a/_layouts/autopage_author.html
+++ b/_layouts/autopage_author.html
@@ -101,12 +101,27 @@ layout: default
   <div class="bg-white py-10 px-14 rounded-lg shadow-md">
     <h2 class="text-2xl font-sans text-navysciam font-bold my-4">Articles publi&eacute;s</h2>
     <div>
-      {% for post in site.posts %}
-        {% if author_username == post.author or post.auteurs contains author_username %}
-          {% include postbox.html %}
-          <br>
-        {% endif %}
+      {% for post in paginator.posts %}
+        {% include postbox.html %}
+        <br>
       {% endfor %}
     </div>
   </div>
+
+  {% if paginator.total_pages > 1 %}
+  <ul class="flex justify-center list-none mt-6">
+    {% if paginator.previous_page %}
+    <li class="mx-2">
+      <a class="bg-gray-200 hover:bg-gray-300 text-black py-2 px-4 rounded"
+        href="{{ paginator.previous_page_path | relative_url | replace: '//', '/' }}">&larr; Articles précédents</a>
+    </li>
+    {% endif %}
+    {% if paginator.next_page %}
+    <li class="mx-2">
+      <a class="bg-gray-200 hover:bg-gray-300 text-black py-2 px-4 rounded"
+        href="{{ paginator.next_page_path | relative_url | replace: '//', '/' }}">Articles suivants &rarr;</a>
+    </li>
+    {% endif %}
+  </ul>
+  {% endif %}
 </div>


### PR DESCRIPTION
Hey! Developer of [`jekyll-auto-authors`](http://rubygems.org/gems/jekyll-auto-authors) here. Thanks for using the plugin :)

I see in your setup that even though auto pages for authors are set up correctly, the actual pagination rendering is not set up. Instead of `paginator.posts`, `site.posts` is used which doesn't allow pagination. Also it increases the build time because jekyll has to iterate through all the posts for every author:

https://github.com/SCIAM-FR/sciam-fr.github.io/blob/181a526f8e41b847ad4a944a70fbb8a900c77ebf/_layouts/autopage_author.html#L101-L112

Instead, in this PR I've changed the logic to how for example your `autopage_tags.html` is set up:

https://github.com/SCIAM-FR/sciam-fr.github.io/blob/181a526f8e41b847ad4a944a70fbb8a900c77ebf/_layouts/autopage_tags.html#L67-L82

This is also recommended in the [example site](https://github.com/gouravkhunger/jekyll-auto-authors/blob/071dfa28fc4fa8b9cf3034acf158b9502c496047/example/_layouts/author.html#L20-L52).
