### PR TITLE
Correction du temps de lecture

### DIFF
--- a/_layouts/autopage_tags.html
+++ b/_layouts/autopage_tags.html
@@ -51,7 +51,7 @@ layout: default
                   author.name }}</a></span>
               <div class="flex">
                 <span class="text-base font-normal text-navysciam">{{ post.date | date: "%d/%m/%Y" }}</span>
-                <p class="text-navysciam pl-2">• {{ post.content | strip_html | reading_time | pluralize: "min" }} de
+                <p class="text-navysciam pl-2">• {{ post.content | reading_time | pluralize: "min" }} de
                   lecture</p>
               </div>
             </div>

--- a/_layouts/list.html
+++ b/_layouts/list.html
@@ -98,7 +98,7 @@ pagination:
               <div class="flex">
                 <span class="text-base font-normal text-navysciam">{{ post.date | date: "%d/%m/%Y" }}</span>
                 {% unless post.vimeo-id %}
-                <p class="text-navysciam pl-2">• {{ post.content | strip_html | reading_time | pluralize: "min" }} de
+                <p class="text-navysciam pl-2">• {{ post.content | reading_time | pluralize: "min" }} de
                   lecture</p>
 		{% endunless %}
               </div>

--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@ layout: default
                           author.name }}</a></span>
                       <div class="flex">
                         <span class="text-base font-normal text-navysciam">{{ post.date | date: "%d/%m/%Y" }}</span>
-                        <p class="text-navysciam pl-2">• {{ post.content | strip_html | reading_time | pluralize: "min" }} de lecture
+                        <p class="text-navysciam pl-2">• {{ post.content | reading_time | pluralize: "min" }} de lecture
                         </p>
                       </div>
                     </div>
@@ -184,7 +184,7 @@ layout: default
                             <a href="{{ '/author/' | append: post.author | append: '/index.html' | relative_url }}">{{ author.name }}</a></span>
                           <div class="flex">
                             <span class="text-base font-normal text-navysciam">{{ post.date | date: "%d/%m/%Y" }}</span>
-                            <p class="text-navysciam pl-2">• {{ post.content | strip_html | reading_time | pluralize: "min" }} de lecture</p>
+                            <p class="text-navysciam pl-2">• {{ post.content | reading_time | pluralize: "min" }} de lecture</p>
                           </div>
                         </div>
                       </div>
@@ -284,7 +284,7 @@ layout: default
                               author.name }}</a></span>
                           <div class="flex">
                             <span class="text-base font-normal text-navysciam">{{ post.date | date: "%d/%m/%Y" }}</span>
-                            <p class="text-navysciam pl-2">• {{ post.content | strip_html | reading_time | pluralize: "min" }} de lecture</p>
+                            <p class="text-navysciam pl-2">• {{ post.content | reading_time | pluralize: "min" }} de lecture</p>
                           </div>
                         </div>
                       </div>


### PR DESCRIPTION
Corrige #115

Ajout du pipe `strip_html` pour donner à manger du "plain text" à `reading_time`.
Affichage cohérent sur toutes les pages.

index
<img width="426" height="169" alt="image" src="https://github.com/user-attachments/assets/ebd40dc6-353e-40a4-b3b2-9d42db436e2e" />

post
<img width="462" height="182" alt="image" src="https://github.com/user-attachments/assets/e424cdc3-e0f8-458d-bcd9-8185418daa01" />

vue software engineering
<img width="543" height="230" alt="image" src="https://github.com/user-attachments/assets/a9143b1e-6dbf-4765-bd9c-955c8ab02d2c" />
